### PR TITLE
Add logout button to page footers

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -179,9 +179,9 @@
   }
 </script>
 
-<div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800">
+<div class="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex flex-col">
   <!-- Main Content -->
-  <main class="max-w-7xl mx-auto px-2 sm:px-4 lg:px-8 pt-2 sm:pt-6">
+  <main class="flex-1 max-w-7xl mx-auto px-2 sm:px-4 lg:px-8 pt-2 sm:pt-6 w-full">
     {#if !isAuthenticated}
       <!-- Landing page for unauthenticated users -->
       <div class="text-center max-w-4xl mx-auto">
@@ -257,6 +257,26 @@
       {/if}
     {/if}
   </main>
+
+  <!-- Footer with Logout for authenticated users -->
+  {#if isAuthenticated}
+    <footer class="mt-auto py-6 px-4 border-t border-slate-200 dark:border-slate-700">
+      <div class="max-w-7xl mx-auto flex items-center justify-between">
+        <p class="text-sm text-slate-600 dark:text-slate-400">
+          Logged in as {user?.email}
+        </p>
+        <button
+          onclick={handleLogout}
+          class="flex items-center space-x-2 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path>
+          </svg>
+          <span>Log out</span>
+        </button>
+      </div>
+    </footer>
+  {/if}
 
   <!-- Auth Modal -->
   {#if showAuthModal}


### PR DESCRIPTION
Add a logout button to the bottom of all authenticated pages.

The user requested a persistent logout option at the bottom of all pages, complementing the existing logout functionality within the user menu. This required adding a footer component and adjusting the main layout to ensure it remains at the bottom.

---
<a href="https://cursor.com/background-agent?bcId=bc-02dd63be-70c9-435c-badf-9188020f4595">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02dd63be-70c9-435c-badf-9188020f4595">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

